### PR TITLE
chore: update repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/holmlibs/unzip"
+		"url": "git+https://github.com/holmlibs/unzip.git"
 	},
 	"keywords": [
 		"bun",


### PR DESCRIPTION
Update the repository URL to include the `.git` suffix for consistency with GitHub's standard format. This ensures compatibility with tools that expect the full repository URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the repository URL format in package metadata for improved compatibility with npm standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->